### PR TITLE
Add ability to blacklist questions by substring

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,6 +40,14 @@
       "description": "Comma-separated list of channel names in which this bot is not allowed to respond",
       "required": false,
       "value": "general"
+    },
+    "QUESTION_SUBSTRING_BLACKLIST": {
+      "description": "Comma-separated list of strings which indicate a question containing any of these should be ignored.",
+      "required": false,
+      "value": [
+        "seen here",
+        "[audio clue]"
+      ]
     }
   }
 }


### PR DESCRIPTION
The main purpose of the blacklist is to filter out questions which
contain an image/audio clue. Phrases like "seen here" and "[audio
clue]" are common in these kinds of questions, so the blacklist can be
used to ignore these.
